### PR TITLE
Fix for issue #13.

### DIFF
--- a/src/application.php
+++ b/src/application.php
@@ -156,7 +156,10 @@ namespace TheSeer\phpDox {
        * @param string $srcDir Source directory to compare xml structure with
        */
       protected function cleanup($srcDir) {
-         $worker = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator($this->xmlDir), \RecursiveIteratorIterator::CHILD_FIRST );
+         $worker = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->xmlDir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+         );
          $len = strlen($this->xmlDir);
          $srcPath = realpath($srcDir);
 


### PR DESCRIPTION
Due to the missing \FilesystemIterator::SKIP_DOTS flag, the cleanup
worker attempted to delete ".." as a child of a directory, which
resulted in the described error. This commit adds the corresponding
flag.
