### PR TITLE
Make the installation instructions copy/pasteable 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ Installation
 Make sure you've installed all the requirements.
 
 Get the source code from GIT:
-    git clone --recursive git@github.com:Username/phpdox.git
+    git clone --recursive git://github.com/theseer/phpdox.git
 
 _Note: If you've forgot the --recursive argument, you'll not have the staticReflection submodule in lib/. So you might want to use:_
     git submodule init


### PR DESCRIPTION
Changed the readme so one doesn't need to copy every single line.

Also removed the "Username" from the git checkout since i assume contributors will figure out how to clone from their own fork everyone else shouldn't be bothered with that.

Aprart from that: 
/var/www/ $ git submodule init

should have read:
cd phpdox;
/var/www/phpdox/ $ git submode init

Cheers,
Edorian
