### PR TITLE
Fixes copy() errors that occur trying to copy the . and .. folders when copying static content

### DIFF
--- a/src/generator.php
+++ b/src/generator.php
@@ -204,6 +204,9 @@ namespace TheSeer\phpDox {
                 $worker = new \DirectoryIterator($path);
             }
             foreach($worker as $x) {
+                if($x->isDir() && ($x->getFilename() == "." || $x->getFilename() == "..")) {
+                    continue;
+                }
                 $target = $this->docDir . substr($x->getPathname(), $len);
                 if (!file_exists(dirname($target))) {
                     mkdir(dirname($target), 0755, true);


### PR DESCRIPTION
It's trying to copy:

string(79) "/home/edo/Desktop/PHP/autodox/phpdox/src/../templates/htmlBuilder/static/gfx/.."
to
string(13) "./docs/gfx/.."

---

Using PHP 5.3.2-1ubuntu so maybe thats the issue but it doesn't seem like it.

Well.. with the patch it works for me

---

Warning: copy(): The first argument to copy() function cannot be a directory in /home/edo/Desktop/PHP/autodox/phpdox/src/generator.php on line 211

Call Stack:
    0.0004     642240   1. {main}() /home/edo/Desktop/PHP/autodox/phpdox/phpdox.php:0
    0.0061    1178768   2. TheSeer\phpDox\CLI->run() /home/edo/Desktop/PHP/autodox/phpdox/phpdox.php:58
    0.0275    2165512   3. TheSeer\phpDox\Application->runGenerator() /home/edo/Desktop/PHP/autodox/phpdox/src/cli.php:116
    0.0331    2705800   4. TheSeer\phpDox\Generator->run() /home/edo/Desktop/PHP/autodox/phpdox/src/application.php:171
    0.0346    2706064   5. TheSeer\phpDox\Generator->triggerEvent() /home/edo/Desktop/PHP/autodox/phpdox/src/generator.php:139
    0.0347    2707408   6. call_user_func_array() /home/edo/Desktop/PHP/autodox/phpdox/src/generator.php:269
    0.0347    2707896   7. TheSeer\phpDox\HtmlBuilder->handle() /home/edo/Desktop/PHP/autodox/phpdox/src/generator.php:0
    0.0347    2708840   8. call_user_func_array() /home/edo/Desktop/PHP/autodox/phpdox/src/builder/htmlbuilder/htmlbuilder.php:68
    0.0347    2709208   9. TheSeer\phpDox\HtmlBuilder->buildFinish() /home/edo/Desktop/PHP/autodox/phpdox/src/builder/htmlbuilder/htmlbuilder.php:0
    0.0347    2709440  10. TheSeer\phpDox\Generator->copyStatic() /home/edo/Desktop/PHP/autodox/phpdox/src/builder/htmlbuilder/htmlbuilder.php:77
    0.0459    2729048  11. copy() /home/edo/Desktop/PHP/autodox/phpdox/src/generator.php:211
