### PR TITLE
Edited src/docblock/parser/varparser.php via GitHub

### DIFF
--- a/src/docblock/parser/varparser.php
+++ b/src/docblock/parser/varparser.php
@@ -45,8 +45,8 @@ namespace TheSeer\phpDox\DocBlock {
          $parts = preg_split("/[\s,]+/", $this->payload, 2, PREG_SPLIT_NO_EMPTY);
          if (count($parts)==2) {
             $obj->setDescription($parts[1]);
+            $obj->setType($parts[0]);
          }
-         $obj->setType($parts[0]);
          return $obj;
       }
 


### PR DESCRIPTION
If parts is empty it throws a notice when trying to set the type because there is nothing in the zeroth offset doesn't exist.
