### PR TITLE
Fix JavaScript inclusion so that it also works in non-Firefox browsers.

### DIFF
--- a/templates/htmlBuilder/static/index.xhtml
+++ b/templates/htmlBuilder/static/index.xhtml
@@ -3,8 +3,8 @@
     <head>
     	<link type="text/css" href="css/class.css" rel="stylesheet"/>
     	<link type="text/css" href="css/style.css" rel="stylesheet"/>
-    	<script type="text/javascript" src="js/jquery-1.6.1.min.js" />
-    	<script type="text/javascript" src="js/phpdox.js" />
+    	<script type="text/javascript" src="js/jquery-1.6.1.min.js"></script>
+    	<script type="text/javascript" src="js/phpdox.js"></script>
     </head>
     <body onload="phpDox.load();">
 	<div id="head"></div>


### PR DESCRIPTION
`<script />` => `<script></script>`
