### PR TITLE
Fixed some config file property expansion issues.

### DIFF
--- a/src/config/GlobalConfig.php
+++ b/src/config/GlobalConfig.php
@@ -102,7 +102,7 @@ namespace TheSeer\phpDox {
             $vars = array(
                 'basedir' => $ctx->getAttribute('basedir', dirname($this->fname)),
 
-                'phpDox.home' => realpath(__DIR__.'/../'),
+                'phpDox.home' => realpath(__DIR__.'/../../'),
                 'phpDox.file' => $this->fname,
                 'phpDox.version' => defined('PHPDOX_VERSION') ? PHPDOX_VERSION : '*UNKNOWN*',
 


### PR DESCRIPTION
- Fixed property resolver only iterating over top-level XML elements.
- Fixed property resolver greedy matching.
- Removed debug code.

I had originally changed the path pointed to by the predefined property 'phpDox.home', but realized (after pushing, of course) that I am using the Pear package and my issue is a result of how the 'templates' folder is moved in 'pear.sh' prior to Pear packaging.
