### PR TITLE
Stability fix

### DIFF
--- a/src/docblock/Parser.php
+++ b/src/docblock/Parser.php
@@ -73,7 +73,7 @@ namespace TheSeer\phpDox\DocBlock {
                     $buffer = array();
 
                     preg_match('/^\@([a-zA-Z0-9_]+)(.*)$/', $line, $lineParts);
-                    $name      = $lineParts[1];
+                    $name      = ( isset($lineParts[1]) ) ? $lineParts[1] : "(nothing)";
                     $payload   = ( isset( $lineParts[2] ) ? trim($lineParts[2]) : '' );
 
                     $this->startParser($name, $payload);


### PR DESCRIPTION
`$lineParts[1]` can become unset in certain situations.

This are probably broken doc comments, however PHPdoX should be able to handle this more gracefully.  This simple patch fixes that.

BTW: Perhaps have a look at my second patch in my "workaround" branch
https://github.com/hilbix/phpdox/commit/52152a184a0aa742784d2133e7525ef39d0fc8c8
as without PHPdoX crashes again on certain input (sorry, I am not allowed to provide a copy of this input).  But this second patch does not properly fix this issue, it's just the way I got PHPdoX running at my side.
