### PR TITLE
Pull request to fix #87

### DIFF
--- a/templates/html/static/css/styles.css
+++ b/templates/html/static/css/styles.css
@@ -139,6 +139,13 @@ ul.inheritance li + li + li + li + li {margin-left: 2em;}
 ul.inheritance li + li + li + li + li + li {margin-left: 2.5em;}
 ul.inheritance li + li + li + li + li + li + li {margin-left: 3em;}
 
+/* ======== method:param, method:return, method:trows  */
+ul.param, ul.return, ul.throws {list-style-type:none;}
+h4.param {margin-bottom: 0px;}
+
+/* ======== method:return, method:trows  */
+h4.return, h4.throws {margin-top: 0px; margin-bottom: 0px;}
+
 /*  ========= Footer */
 .footer	{clear:both;margin:2em 0 1em 0;padding:0.5em 1em;border-top:2px solid #cecece;font-size: 0.85em;}
 

--- a/templates/html/unit.xsl
+++ b/templates/html/unit.xsl
@@ -169,6 +169,24 @@
         </li>
     </xsl:template>    
 
+    <xsl:template match="src:param">
+        <li>
+            <code><xsl:value-of select="@variable" /></code> - <xsl:value-of select="@description" />
+        </li>
+    </xsl:template>
+
+    <xsl:template match="src:return">
+        <li>
+            <xsl:value-of select="@description" />
+        </li>
+    </xsl:template>
+
+    <xsl:template match="src:throws">
+        <li>
+            <code><xsl:value-of select="@value" /></code>
+        </li>
+    </xsl:template>
+
     <xsl:template match="src:author">
         <li>
             <b>Author: </b> <xsl:value-of select="@value" />
@@ -249,6 +267,30 @@
                 <p style="font-size:110%; padding-top:5px;">
                     <xsl:apply-templates select="src:description" />
                 </p>
+                <xsl:if test="count(src:param)>0">
+                    <ul>
+                        <h4 class="param">Parameters:</h4>
+                        <ul class="param">
+                            <xsl:apply-templates select="src:param" />
+                        </ul>
+                    </ul>
+                </xsl:if>
+                <xsl:if test="count(src:return)>0">
+                    <ul>
+                        <h4 class="return">Returns:</h4>
+                        <ul class="return">
+                            <xsl:apply-templates select="src:return" />
+                        </ul>
+                    </ul>
+                </xsl:if>
+                <xsl:if test="count(src:throws)>0">
+                    <ul>
+                        <h4 class="throws">Throws:</h4>
+                        <ul class="throws">
+                            <xsl:apply-templates select="src:throws" />
+                        </ul>
+                    </ul>
+                </xsl:if>
             </xsl:for-each>
         </li>
     </xsl:template>    


### PR DESCRIPTION
Generated documentation will now display this parts of method docblock: param, return, throws.

Refered to issue #87
