### PR TITLE
changed version to 0.4.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,7 +29,7 @@ Depending on your OS distribution and/or your PHP environment, you may need to i
 The following two commands (which you may have to run as `root`) are all that is required to install phpDox using the PEAR Installer:
 
     sudo pear config-set auto_discover 1
-    sudo pear install pear.netpirates.net/phpDox
+    sudo pear install pear.netpirates.net/phpDox-0.4.0
 
 This should take care of installing all the required dependencies for you.
 


### PR DESCRIPTION
... since without explicit version one gets an error from pear:

```
Failed to download theseer/phpDox within preferred state "stable", latest release is version 0.4.0, stability "alpha", use "channel://pear.netpirates.net/phpDox-0.4.0" to install
install failed
```
