### PR TITLE
Update README.markdown => PHPParser-0.9.3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,7 +48,7 @@ _Note: The `phpdox.php` bootstrap file assumes that all depedencies have been in
 To make things work, you now have to manually install the following dependencies using the PEAR Installer (or clone their repositories and then adjust the paths in the `phpdox.php` bootstrap file):
 
     pear channel-discover nikic.github.com/pear
-    pear install channel://nikic.github.com/pear/PHPParser-0.9.2
+    pear install channel://nikic.github.com/pear/PHPParser-0.9.3
     sudo pear install phpunit/PHP_Timer
     sudo pear install ezc/ConsoleTools
     sudo pear install theseer/DirectoryScanner


### PR DESCRIPTION
$ pear install pear.netpirates.net/phpDox-0.5.0
Failed to download nikic/PHPParser within preferred state "stable", latest release is version 0.9.3, stability "beta", use "channel://nikic.github.com/pear/PHPParser-0.9.3" to install
theseer/phpDox requires package "nikic/PHPParser" (version >= 0.9.3)
No valid packages found
install failed
