### PR TITLE
Adding extension requirements to package managers.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "phpunit/php-timer" : ">=1.0.4",
     "zetacomponents/base": ">=1.8.0",
     "zetacomponents/console-tools" : ">=1.6.0",
-    "nikic/php-parser" : ">=0.9.3"
+    "nikic/php-parser" : ">=0.9.3",
+    "ext-fileinfo": "*"
   },
   "autoload": {
     "classmap": [

--- a/package.xml
+++ b/package.xml
@@ -93,6 +93,9 @@
        <extension>
         <name>iconv</name>
        </extension>
+       <extension>
+        <name>fileinfo</name>
+       </extension>
       </required>
      </dependencies>
      <phprelease>


### PR DESCRIPTION
fileinfo is a required php extension which is disabled in some userland environments.
