### PR TITLE
Small corrections to the readme file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -88,11 +88,11 @@ Trouble Shooting
         No valid packages found
         install failed
 
-    Try to install the xsl extention of PHP. On Ubuntu, you can simply use:
+    Try to install the xsl extension of PHP. On Ubuntu, you can simply use:
 
         sudo apt-get install php5-xsl
         
-    For Redhat based distributions:
+    For Red Hat based distributions:
     
         sudo yum install php-xsl
 


### PR DESCRIPTION
The usage examples section states that "The examples assume you installed phpDox from pear." - hence all the examples should use 'phpdox' instead of 'phpdox.php'.

I also found two typos in the trouble shooting section.
