### PR TITLE
Omit 'inherited from' heading if there are no extended methods

### DIFF
--- a/templates/html/components.xsl
+++ b/templates/html/components.xsl
@@ -379,7 +379,9 @@
 
         <xsl:if test="$ctx/pdx:extends">
             <xsl:variable name="parent" select="$unit/pdx:parent[@full = $ctx/pdx:extends/@full]" />
-            <h3>Inherited from <xsl:copy-of select="pdxf:link($parent, '', $parent/@full)" /></h3>
+            <xsl:if test="count($parent/pdx:method) > 0">
+                <h3>Inherited from <xsl:copy-of select="pdxf:link($parent, '', $parent/@full)" /></h3>
+            </xsl:if>
             <xsl:if test="$parent/pdx:method[@visibility='protected']">
                 <h4>protected</h4>
                 <ul>


### PR DESCRIPTION
If the collector does not resolve inheritance the generator still writes the 'inherited from' heading into the output, although there are no methods listed underneath it.

This configuration:

``` xml
<project name="apidox" source="${basedir}/src" workdir="${basedir}/build/apidox/xml">
    <!--  Additional configuration for the collecting process (parse of php code, generation of xml data) -->
    <collector publiconly="true" backend="parser">
        <include mask="*.php"/>
        <exclude mask=""/>
        <!--  How to handle inheritance -->
        <inheritance resolve="false"/>
    </collector>

    <!--  Configuration of generation process -->
    <generator output="${basedir}/apidocs">
        <enrich base="${basedir}/build"/>

        <build engine="html" enabled="true" output="html">
            <template dir="${phpDox.home}/templates/html"/>
            <file extension="xhtml"/>
        </build>

    </generator>
</project>
```

leads to this output for a class that extends another class:

``` html
<h2 id="methods">Methods</h2>
<div class="styled">
    <h4>public</h4>
    <ul>
        <li id="foo">
            <a title="B" href="../classes/B/foo.xhtml">foo()</a>
            — Method foo in Class B
        </li>
    </ul>
    <h3>
        Inherited from
        <a title="" href="../classes/.xhtml"></a>
    </h3>
</div>
```

The h3 element shouldn't be there.
