### PR TITLE
Avoid "NaN" output

### DIFF
--- a/templates/html/class.xsl
+++ b/templates/html/class.xsl
@@ -146,14 +146,14 @@
                 <xsl:variable name="methods"  select="count($unit/pdx:method|$unit/pdx:constructor|$unit/pdx:destructor)" />
                 <xsl:variable name="executed" select="count($unit//pdx:enrichments/pdx:enrichment[@type='phpunit']/pu:coverage[@coverage = '100'])" />
                 <td>Methods</td>
-                <td class="percent"><xsl:value-of select="format-number($executed div $methods * 100, '0.##')" />%</td>
+                <td class="percent"><xsl:value-of select="pdxf:format-number($executed div $methods * 100, '0.##')" />%</td>
                 <td class="nummeric"><xsl:value-of select="$executed" /> / <xsl:value-of select="$methods" /></td>
             </tr>
             <tr>
                 <xsl:variable name="executed"    select="$unit/pdx:enrichments/pdx:enrichment[@type='phpunit']/pu:coverage/@executed" />
                 <xsl:variable name="executable"  select="$unit/pdx:enrichments/pdx:enrichment[@type='phpunit']/pu:coverage/@executable" />
                 <td>Lines</td>
-                <td class="percent"><xsl:value-of select="format-number($executed div $executable * 100, '0.##')" />%</td>
+                <td class="percent"><xsl:value-of select="pdxf:format-number($executed div $executable * 100, '0.##')" />%</td>
                 <td class="nummeric"><xsl:value-of select="$executed" /> / <xsl:value-of select="$executable" /></td>
             </tr>
         </table>

--- a/templates/html/functions.xsl
+++ b/templates/html/functions.xsl
@@ -56,4 +56,19 @@
             <func:result><xsl:copy-of select="$format" /></func:result>
     </func:function>
 
+    <func:function name="pdxf:format-number">
+        <xsl:param name="value"/>
+        <xsl:param name="format">0.##</xsl:param>
+            <func:result>
+                <xsl:choose>
+                <xsl:when test="string(number($value))='NaN'">
+                    <xsl:value-of select="format-number(0, $format)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="format-number($value, $format)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </func:result>
+    </func:function>
+
 </xsl:stylesheet>

--- a/templates/html/index.xsl
+++ b/templates/html/index.xsl
@@ -1,8 +1,10 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:git="http://xml.phpdox.net/gitlog#"
-                xmlns:pdx="http://xml.phpdox.net/src#">
+                xmlns:pdx="http://xml.phpdox.net/src#"
+                xmlns:pdxf="http://xml.phpdox.net/functions">
 
+    <xsl:import href="functions.xsl"/>
     <xsl:import href="components.xsl" />
 
     <xsl:output method="xml" indent="yes" encoding="UTF-8" doctype-system="about:legacy-compat" />
@@ -91,12 +93,12 @@
                     <tr>
                         <td class="indent">Abstract Classes</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:abstractClasses" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:abstractClasses div $phploc/pdx:classes * 100, '0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:abstractClasses div $phploc/pdx:classes * 100, '0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Concrete Classes</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:concreteClasses" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:concreteClasses div $phploc/pdx:classes * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:concreteClasses div $phploc/pdx:classes * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td>Methods</td>
@@ -111,12 +113,12 @@
                     <tr>
                         <td class="indent2">Non-Static Methods</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:nonStaticMethods" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:nonStaticMethods div $phploc/pdx:methods * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:nonStaticMethods div $phploc/pdx:methods * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent2">Static Methods</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:staticMethods" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:staticMethods div $phploc/pdx:methods * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:staticMethods div $phploc/pdx:methods * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Visibility</td>
@@ -126,12 +128,12 @@
                     <tr>
                         <td class="indent2">Public Method</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:publicMethods" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:publicMethods div $phploc/pdx:methods * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:publicMethods div $phploc/pdx:methods * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent2">Non-Public Methods</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:nonPublicMethods" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:nonPublicMethods div $phploc/pdx:methods * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:nonPublicMethods div $phploc/pdx:methods * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td>Functions</td>
@@ -141,12 +143,12 @@
                     <tr>
                         <td class="indent">Named Functions</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:namedFunctions" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:namedFunctions div $phploc/pdx:functions * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:namedFunctions div $phploc/pdx:functions * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Anonymous Functions</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:anonymousFunctions" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:anonymousFunctions div $phploc/pdx:functions * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:anonymousFunctions div $phploc/pdx:functions * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td>Constants</td>
@@ -156,12 +158,12 @@
                     <tr>
                         <td class="indent">Global Constants</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:globalConstants" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:globalConstants div $phploc/pdx:constants * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:globalConstants div $phploc/pdx:constants * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Class Constants</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:classConstants" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:classConstants div $phploc/pdx:constants * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:classConstants div $phploc/pdx:constants * 100,'0.##')" />%)</td>
                     </tr>
                 </table>
             </div>
@@ -193,22 +195,22 @@
                     <tr>
                         <td>Comment Lines of Code (CLOC)</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:cloc" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:cloc div $phploc/pdx:loc * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:cloc div $phploc/pdx:loc * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td>Non-Comment Lines of Code (NCLOC)</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:ncloc" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:ncloc div $phploc/pdx:loc * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:ncloc div $phploc/pdx:loc * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td>Logical Lines of Code (LLOC)</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:lloc" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:lloc div $phploc/pdx:loc * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:lloc div $phploc/pdx:loc * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td>Classes</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:llocClasses" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:llocClasses div $phploc/pdx:lloc * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:llocClasses div $phploc/pdx:lloc * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Average Class Length</td>
@@ -223,7 +225,7 @@
                     <tr>
                         <td>Functions</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:llocFunctions" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:llocFunctions div $phploc/pdx:lloc * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:llocFunctions div $phploc/pdx:lloc * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Average Function Length</td>
@@ -233,7 +235,7 @@
                     <tr>
                         <td>Not in classes or functions</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:llocGlobal" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:llocGlobal div $phploc/pdx:lloc * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:llocGlobal div $phploc/pdx:lloc * 100,'0.##')" />%)</td>
                     </tr>
                 </table>
             </div>
@@ -243,12 +245,12 @@
                 <table class="styled overview">
                     <tr>
                         <td>Cyclomatic Complexity / LLOC</td>
-                        <td class="nummeric"><xsl:value-of select="format-number($phploc/pdx:ccnByLloc, '0.##')" /></td>
+                        <td class="nummeric"><xsl:value-of select="pdxf:format-number($phploc/pdx:ccnByLloc, '0.##')" /></td>
                         <td class="percent"/>
                     </tr>
                     <tr>
                         <td>Cyclomatic Complexity / Number of Methods</td>
-                        <td class="nummeric"><xsl:value-of select="format-number($phploc/pdx:ccnByNom, '0.##')" /></td>
+                        <td class="nummeric"><xsl:value-of select="pdxf:format-number($phploc/pdx:ccnByNom, '0.##')" /></td>
                         <td class="percent"/>
                     </tr>
                 </table>
@@ -265,17 +267,17 @@
                     <tr>
                         <td class="indent">Global Constants</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:globalConstantAccesses" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:globalConstantAccesses div $phploc/pdx:globalAccesses * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:globalConstantAccesses div $phploc/pdx:globalAccesses * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Global Variables</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:globalVariableAccesses" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:globalVariableAccesses div $phploc/pdx:globalAccesses * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:globalVariableAccesses div $phploc/pdx:globalAccesses * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Super-Global Variables</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:superGlobalVariableAccesses" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:superGlobalVariableAccesses div $phploc/pdx:globalAccesses * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:superGlobalVariableAccesses div $phploc/pdx:globalAccesses * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td>Attribute Accesses</td>
@@ -285,12 +287,12 @@
                     <tr>
                         <td class="indent">Non-Static</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:instanceAttributeAccesses" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:instanceAttributeAccesses div $phploc/pdx:attributeAccesses * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:instanceAttributeAccesses div $phploc/pdx:attributeAccesses * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Static</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:staticAttributeAccesses" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:staticAttributeAccesses div $phploc/pdx:attributeAccesses * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:staticAttributeAccesses div $phploc/pdx:attributeAccesses * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td>Method Calls</td>
@@ -300,12 +302,12 @@
                     <tr>
                         <td class="indent">Non-Static</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:instanceMethodCalls" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:instanceMethodCalls div $phploc/pdx:methodCalls * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:instanceMethodCalls div $phploc/pdx:methodCalls * 100,'0.##')" />%)</td>
                     </tr>
                     <tr>
                         <td class="indent">Static</td>
                         <td class="nummeric"><xsl:value-of select="$phploc/pdx:staticMethodCalls" /></td>
-                        <td class="percent">(<xsl:value-of select="format-number($phploc/pdx:staticMethodCalls div $phploc/pdx:methodCalls * 100,'0.##')" />%)</td>
+                        <td class="percent">(<xsl:value-of select="pdxf:format-number($phploc/pdx:staticMethodCalls div $phploc/pdx:methodCalls * 100,'0.##')" />%)</td>
                     </tr>
                 </table>
             </div>

--- a/templates/html/method.xsl
+++ b/templates/html/method.xsl
@@ -281,7 +281,7 @@
                 <li>Tests: <xsl:value-of select="$count" /></li>
                 <li>Passed: <xsl:value-of select="$passed" /> (<xsl:choose>
                     <xsl:when test="$count = 0">0</xsl:when>
-                    <xsl:otherwise><xsl:value-of select="format-number($passed div $count * 100,'0.##')" /></xsl:otherwise>
+                    <xsl:otherwise><xsl:value-of select="pdxf:format-number($passed div $count * 100,'0.##')" /></xsl:otherwise>
                 </xsl:choose>%)</li>
             </ul>
             <xsl:if test="$method//pdx:enrichment[@type='phpunit']/pu:coverage/pu:test">


### PR DESCRIPTION
It uses a custom number format function to avoid "NaN%" outputs.
