### PR TITLE
Document minimum-stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "theseer/directoryscanner" : ">=1.3.0",
     "theseer/fxsl" : ">=1.1",
     "phpunit/php-timer" : ">=1.0.4",
-    "nikic/php-parser" : ">=1.0.0"
+    "nikic/php-parser" : ">=1.0.0@beta"
   },
   "autoload": {
     "classmap": [


### PR DESCRIPTION
Allow picky Composer parsers to actually rely on the currently available
1.0.0beta1 version of PHP-Parser.
