### PR TITLE
properly parse docblock annotations

### DIFF
--- a/src/docblock/InlineProcessor.php
+++ b/src/docblock/InlineProcessor.php
@@ -86,7 +86,7 @@ namespace TheSeer\phpDox\DocBlock {
             }
             $parts = preg_split("/[\s,]+/", $match, 2, PREG_SPLIT_NO_EMPTY);
             $annotation = substr($parts[0], 1);
-            if (preg_match('=[a-zA-Z0-9]=', $annotation)) {
+            if (preg_match('=^[a-zA-Z0-9]*$=', $annotation)) {
                 $parser = $this->factory->getParserInstanceFor($annotation);
             } else {
                 $parser = $this->factory->getParserInstanceFor('invalid', $annotation);


### PR DESCRIPTION
The old regex would allow docblocks like:
    /**
     \* @var \Doctrine\Common\Collections\Collection
     *
     \* @ORM\ManyToMany(targetEntity="PriceList", inversedBy="areas", fetch="EXTRA_LAZY")
     \* @ORM\JoinTable(name="area_has_pricelist",
     \*      joinColumns={@ORM\JoinColumn(name="area_id", referencedColumnName="id")},
     \*      inverseJoinColumns={@ORM\JoinColumn(name="pricelist_id", referencedColumnName="id")}
     \* )
     */

But that would crash later on when trying to create a dom node with the generic
docblock element because the name gets parsed into Orm\JoinColumn(...
and the generic docblock elementry tries to create an dom element with that
name as a tag.
