### PR TITLE
Vendor directory location change for phpdox as dependency

### DIFF
--- a/phpdox
+++ b/phpdox
@@ -43,7 +43,7 @@
 require __DIR__ . '/src/autoload.php';
 
 $found = false;
-foreach(array(__DIR__ . '/vendor', __DIR__ . '/../../vendor') as $vendor) {
+foreach(array(__DIR__ . '/vendor', __DIR__ . '/../../../vendor') as $vendor) {
     if (file_exists($vendor)) {
         $found = true;
         require __DIR__ . '/src/vendor.php';


### PR DESCRIPTION
Since `__DIR__` seems to report as vendor/theseer/phpdox, we need to go up one more level to find the directory that contains the vendor directory.
