### PR TITLE
fix array to string conversion notices

### DIFF
--- a/src/collector/InheritanceResolver.php
+++ b/src/collector/InheritanceResolver.php
@@ -162,7 +162,7 @@ namespace TheSeer\phpDox\Collector {
                         $extendedUnit = $this->getUnitByName($name);
                         $this->processExtends($unit, $extendedUnit, $extendedUnit);
                     } catch (ProjectException $e) {
-                        $this->addUnresolved($unit, $extends->getExtends());
+                        $this->addUnresolved($unit, $name);
                     }
                 }
             }
@@ -227,7 +227,7 @@ namespace TheSeer\phpDox\Collector {
                         $extendedUnit = $this->getUnitByName($name);
                         $this->processExtends($unit, $extendedUnit, $extendedUnit);
                     } catch (ProjectException $e) {
-                        $this->addUnresolved($unit, $trait->getExtends());
+                        $this->addUnresolved($unit, $name);
                     }
                 }
             }


### PR DESCRIPTION
fixes notice:

``````
PHP Version: 5.6.4-1~dotdeb.1 (Linux)
PHPDox Version: c4f9402-dirty
ErrorException: E_NOTICE 
Location: .../vendor/theseer/phpdox/src/collector/project/AbstractUnitObject.php (Line 344)

Array to string conversion

#0 .../vendor/theseer/phpdox/src/collector/project/AbstractUnitObject.php(344): sprintf()
#1 .../vendor/theseer/phpdox/src/collector/InheritanceResolver.php(148): TheSeer\phpDox\Collector\AbstractUnitObject->markDependencyAsUnresolved()
#2 .../vendor/theseer/phpdox/src/collector/InheritanceResolver.php(165): TheSeer\phpDox\Collector\InheritanceResolver->addUnresolved()
#3 .../vendor/theseer/phpdox/src/collector/InheritanceResolver.php(92): TheSeer\phpDox\Collector\InheritanceResolver->processExtends()
#4 .../vendor/theseer/phpdox/src/Application.php(145): TheSeer\phpDox\Collector\InheritanceResolver->resolve()
#5 .../vendor/theseer/phpdox/src/CLI.php(156): TheSeer\phpDox\Application->runCollector()
#6 .../vendor/theseer/phpdox/phpdox(65): TheSeer\phpDox\CLI->run()
```