### PR TITLE
Fix broken tests

### DIFF
--- a/src/docblock/Factory.php
+++ b/src/docblock/Factory.php
@@ -67,11 +67,12 @@ namespace TheSeer\phpDox\DocBlock {
          * Register a parser factory.
          *
          * @param string $annotation Identifier of the parser within the registry.
-         * @param \TheSeer\phpDox\FactoryInterface $factory Instance of the factory to be registered.
+         * @param \TheSeer\phpDox\FactoryInterface|string $factory Instance of FactoryInterface to be registered or FQCN
+         *        of the object to be created.
          *
-         * @throws FactoryException in case either one or both arguments are not of type string.
+         * @throws FactoryException in case $annotation is not a string.
          */
-        public function addParserFactory($annotation, FactoryInterface $factory) {
+        public function addParserFactory($annotation, $factory) {
             $this->verifyType($annotation);
             $this->parserMap[$annotation] = $factory;
         }

--- a/tests/Integration/docblock/factoryTest.php
+++ b/tests/Integration/docblock/factoryTest.php
@@ -104,20 +104,17 @@ namespace TheSeer\phpDox\Tests\Integration\DocBlock {
          */
         public function testGetInstanceByMapHandlingAFactory() {
 
-            $factoryStub = $this->getMockBuilder('TheSeer\\phpDox\\DocBlock\\Factory')
-                ->setMethods(array('getInstanceFor'))
-                ->setMockClassName('GnuFactory')
-                ->getMock();
-            $factoryStub
+            $factoryMock = $this->getMock('TheSeer\\phpDox\\FactoryInterface');
+            $factoryMock
                 ->expects($this->once())
                 ->method('getInstanceFor')
                 ->will($this->returnValue(new \stdClass));
 
             $factory = new FactoryProxy();
-            $factory->addParserFactory('GnuFactory', $factoryStub);
+
             $this->assertInstanceOf(
                 '\stdClass',
-                $factory->getInstanceByMap($factory->parserMap, 'GnuFactory')
+                $factory->getInstanceByMap(array('GnuFactory' => $factoryMock), 'GnuFactory')
             );
         }
 
@@ -174,20 +171,6 @@ namespace TheSeer\phpDox\Tests\Integration\DocBlock {
     }
 
     class FactoryProxy extends Factory {
-
-        public $parserMap = array(
-            'invalid' => 'TheSeer\\phpDox\\DocBlock\\InvalidParser',
-            'generic' => 'TheSeer\\phpDox\\DocBlock\\GenericParser',
-
-            'description' => 'TheSeer\\phpDox\\DocBlock\\DescriptionParser',
-            'param' => 'TheSeer\\phpDox\\DocBlock\\ParamParser',
-            'var' => 'TheSeer\\phpDox\\DocBlock\\VarParser',
-            'return' => 'TheSeer\\phpDox\\DocBlock\\VarParser',
-            'license' => 'TheSeer\\phpDox\\DocBlock\\LicenseParser',
-
-            'internal' => 'TheSeer\\phpDox\\DocBlock\\InternalParser'
-        );
-
         public function getInstanceByMap($map, $name, $annotation = null) {
             return parent::getInstanceByMap($map, $name, $annotation);
         }

--- a/tests/Integration/factoryTest.php
+++ b/tests/Integration/factoryTest.php
@@ -39,6 +39,7 @@
 namespace TheSeer\phpDox\Tests\Integration {
 
     use TheSeer\phpDox\Factory;
+    use TheSeer\phpDox\FileInfo;
 
     /**
      * Class FactoryTest
@@ -60,7 +61,7 @@ namespace TheSeer\phpDox\Tests\Integration {
         public function testGetApplication() {
             $this->assertInstanceOf(
                 'TheSeer\\phpDox\\Application',
-                $this->factory->getInstanceFor('Application')
+                $this->factory->getApplication()
             );
         }
 
@@ -69,10 +70,27 @@ namespace TheSeer\phpDox\Tests\Integration {
          * @uses TheSeer\phpDox\Collector\Collector
          */
         public function testGetCollector() {
-            $dir1 = new \TheSeer\phpDox\FileInfo('');
+            $fileInfo = new FileInfo('/path/to/file');
+
+            $config = $this->getMockBuilder('TheSeer\phpDox\CollectorConfig')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            $config->expects($this->once())
+                ->method('getSourceDirectory')
+                ->will($this->returnValue($fileInfo));
+
+            $config->expects($this->once())
+                ->method('getWorkDirectory')
+                ->will($this->returnValue($fileInfo));
+
+            $config->expects($this->once())
+                ->method('getBackend')
+                ->will($this->returnValue('parser'));
+
             $this->assertInstanceOf(
                 'TheSeer\\phpDox\\Collector\\Collector',
-                $this->factory->getInstanceFor('Collector', $dir1, $dir1)
+                $this->factory->getCollector($config)
             );
         }
 
@@ -83,7 +101,7 @@ namespace TheSeer\phpDox\Tests\Integration {
         public function testGetGenerator() {
             $this->assertInstanceOf(
                 'TheSeer\\phpDox\\Generator\\Generator',
-                $this->factory->getInstanceFor('Generator')
+                $this->factory->getGenerator()
             );
         }
 
@@ -92,7 +110,7 @@ namespace TheSeer\phpDox\Tests\Integration {
          * @uses TheSeer\phpDox\DocBlock\Factory
          */
         public function testgetDoclockFactory() {
-            $docBlock = $this->factory->getInstanceFor('DocblockFactory');
+            $docBlock = $this->factory->getDocblockFactory();
 
             // lazy initialization included
             $this->assertInstanceOf(
@@ -100,7 +118,7 @@ namespace TheSeer\phpDox\Tests\Integration {
                 $docBlock
             );
 
-            $this->assertSame($docBlock, $this->factory->getInstanceFor('DocblockFactory'));
+            $this->assertSame($docBlock, $this->factory->getDocblockFactory());
         }
 
         /**
@@ -108,7 +126,7 @@ namespace TheSeer\phpDox\Tests\Integration {
          * @uses TheSeer\phpDox\DocBlock\Parser
          */
         public function testgetDoclockParser() {
-            $docBlock = $this->factory->getInstanceFor('DocblockParser');
+            $docBlock = $this->factory->getDocblockParser();
 
             // lazy initialization included
             $this->assertInstanceOf(
@@ -116,7 +134,7 @@ namespace TheSeer\phpDox\Tests\Integration {
                 $docBlock
             );
 
-            $this->assertSame($docBlock, $this->factory->getInstanceFor('DocblockParser'));
+            $this->assertSame($docBlock, $this->factory->getDocblockParser());
         }
 
     }

--- a/tests/Unit/docblock/factoryTest.php
+++ b/tests/Unit/docblock/factoryTest.php
@@ -86,35 +86,37 @@ namespace TheSeer\phpDox\Tests\Unit\DocBlock {
         }
 
         /**
-         * @covers TheSeer\phpDox\DocBlock\Factory::getInstanceFor
+         * @covers TheSeer\phpDox\DocBlock\Factory::getDocBlock
          * @uses TheSeer\phpDox\DocBlock\DocBlock
          */
         public function testGetInstanceForDocBlock() {
             $factory = new Factory();
             $this->assertInstanceOf(
                 'TheSeer\\phpDox\\DocBlock\\DocBlock',
-                $factory->getInstanceFor('DocBlock')
+                $factory->getDocBlock()
             );
         }
 
         /**
-         * @covers TheSeer\phpDox\DocBlock\Factory::getInstanceFor
+         * @covers TheSeer\phpDox\DocBlock\Factory::getInlineProcessor
          * @uses TheSeer\phpDox\DocBlock\InlineProcessor
          */
         public function testGetInstanceForInlineProcessor() {
             $factory = new Factory();
             $this->assertInstanceOf(
                 'TheSeer\\phpDox\\DocBlock\\InlineProcessor',
-                $factory->getInstanceFor('InlineProcessor', new fDOMDocument()));
+                $factory->getInlineProcessor(new fDOMDocument()));
         }
 
         /**
-         * @expectedException \TheSeer\phpDox\DocBlock\FactoryException
-         * @covers TheSeer\phpDox\DocBlock\Factory::getInstanceFor
+         * @covers TheSeer\phpDox\DocBlock\Factory::getParserInstanceFor
          */
-        public function testGetInstanceForExpectingFactoryException() {
+        public function testGetParserInstanceForExpectingFactoryException() {
             $factory = new Factory();
-            $factory->getInstanceFor('invalid Parser');
+            $this->assertInstanceOf(
+                'TheSeer\\phpDox\\DocBlock\\GenericParser',
+                $factory->getParserInstanceFor('invalid Parser')
+            );
         }
 
         /*********************************************************************/

--- a/tests/Unit/docblock/factoryTest.php
+++ b/tests/Unit/docblock/factoryTest.php
@@ -123,13 +123,6 @@ namespace TheSeer\phpDox\Tests\Unit\DocBlock {
         /* Dataprovider                                                      */
         /*********************************************************************/
 
-        public static function verifyTypeClassDataprovider() {
-            return array(
-                'Invalid type' => array(42, 'string'),
-                'unknown type' => array(42, 'integer'),
-            );
-        }
-
         public static function addParserClassDataprovider() {
             return array(
                 'wrong annotation type' => array(array(), 'Gnu'),


### PR DESCRIPTION
I was trying to fix another issue when I found the test suite was broken. It seems phpDox is being refactored, with some parts being simplified.

The fixes are as straightforward as possible.

There is only one change to implementation code, in `TheSeer\phpDox\DocBlock\Factory::addParserFactory`. It respects the changes introduced in commit [66c58d0c7](https://github.com/theseer/phpdox/commit/66c58d0c7e956a2cca6599b79412d951011cc727), where the implicit API for factories was removed. Also, `TheSeer\phpDox\DocBlock\Factory::getInstanceByMap` creates a mapped object (using the `new` operator) using its FQCN if it is not a `TheSeer\phpDox\FactoryInterface`. This change fixes the following tests:

- `TheSeer\phpDox\Tests\Unit\DocBlock\FactoryTest::testAddParserFactory`
- `TheSeer\phpDox\Tests\Unit\DocBlock\FactoryTest::testAddParserFactoryExpectingFactoryException`