### PR TITLE
Change build state logic

### DIFF
--- a/templates/html/units.xsl
+++ b/templates/html/units.xsl
@@ -74,10 +74,7 @@
         <xsl:param name="class" />
 
         <xsl:choose>
-            <xsl:when test="$class//pu:coverage/@executable = 0">
-                <xsl:attribute name="class">testresult-EMPTY</xsl:attribute>EMPTY</xsl:when>
-
-            <xsl:otherwise>
+            <xsl:when test="$class//pu:coverage/@coverage != 0 or $class//pu:coverage/@executable != 0">
                 <xsl:variable name="result" select="$class//pu:result" />
                 <xsl:choose>
                     <!-- all 0 or skipped or incomplete -->
@@ -91,10 +88,12 @@
                     <!-- everything 0 except passed -->
                     <xsl:when test="sum($result/@*) = $result/@passed and $result/@passed != 0">
                         <xsl:attribute name="class">testresult-PASSED</xsl:attribute>PASSED</xsl:when>
-
                 </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- interfaces, empty classes and/or absence of coverage data -->
+                <xsl:attribute name="class">testresult-EMPTY</xsl:attribute>EMPTY
             </xsl:otherwise>
-
         </xsl:choose>
 
     </xsl:template>


### PR DESCRIPTION
I found some cases where the classes were marked as `UNTESTED` while they should be marked as `EMPTY` (classes without implementation code, for example).

I also found some cases where test covered classes that were marked as `EMPTY` because the executable lines was equal to 0 (not sure if it is a PHP_CodeCoverage issue or a phpDox issue). At least the change fixed both issues.

I created a [repository](https://github.com/eriksencosta/phpdox-buildstate) with example code that shows best what the change does in action.