### PR TITLE
Fix the "Source" links extensions

### DIFF
--- a/templates/html/class.xsl
+++ b/templates/html/class.xsl
@@ -134,7 +134,7 @@
                 <li><a href="#history">History</a></li>
                 </xsl:if>
                 <xsl:if test="$unit/@start"><!-- hack: test for start line == we know something about this class -->
-                <li><a href="{$base}source/{$unit/pdx:file/@relative}.xhtml#line{$unit/@start}">Source</a></li>
+                <li><a href="{$base}source/{$unit/pdx:file/@relative}.{$extension}#line{$unit/@start}">Source</a></li>
                 </xsl:if>
             </ul>
         </nav>

--- a/templates/html/interface.xsl
+++ b/templates/html/interface.xsl
@@ -104,7 +104,7 @@
                 <li><a href="#methods">Methods</a></li>
                 </xsl:if>
                 <xsl:if test="$unit/@start"><!-- hack: test for start line == we know something about this class -->
-                    <li><a href="{$base}source/{$unit/pdx:file/@relative}.xhtml#line{$unit/@start}">Source</a></li>
+                    <li><a href="{$base}source/{$unit/pdx:file/@relative}.{$extension}#line{$unit/@start}">Source</a></li>
                 </xsl:if>
             </ul>
         </nav>

--- a/templates/html/method.xsl
+++ b/templates/html/method.xsl
@@ -137,7 +137,7 @@
                     <li><a href="#tasks">Tasks</a></li>
                 </xsl:if>
                 <xsl:if test="$unit/@start"><!-- hack: test for start line == we know something about this class -->
-                    <li><a href="{$base}source/{$unit/pdx:file/@relative}.xhtml#line{$method/@start}">Source</a></li>
+                    <li><a href="{$base}source/{$unit/pdx:file/@relative}.{$extension}#line{$method/@start}">Source</a></li>
                 </xsl:if>
 
             </ul>


### PR DESCRIPTION
The source links were using the hardcoded xhtml extension, ignoring completely the file extension setting.