### PR TITLE
Make links on namespaces page more obvious

### DIFF
--- a/templates/html/static/css/style.css
+++ b/templates/html/static/css/style.css
@@ -163,6 +163,25 @@ h3 {
     text-align: right;
 }
 
+.nummeric a {
+    display: block;
+    background-color: #CCD;
+    padding: 0 0.5em;
+}
+
+.nummeric a:hover, .nummeric a:focus, .nummeric a:active {
+    background-color: #DDE;
+    outline: dotted 2px #AAB;
+}
+
+.nummeric a:hover {
+    outline-style: solid;
+}
+
+.nummeric a:active {
+    outline: solid 2px #667;
+}
+
 .percent {
     text-align: right;
     width:5em;


### PR DESCRIPTION
* Make the links block-level so they mostly fill the table cell.
* Change the background color.
* Highlight on hover.

This is similar to #206, in that it makes it easier to find and follow the links. But it does this by making them more obviously clickable. The colors I chose are somewhat arbitrary. Although I believe they work pretty well, they can certainly be changed.