### PR TITLE
[TASK] Relax requirement constraints for nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "theseer/directoryscanner" : ">=1.3.0",
     "theseer/fxsl" : ">=1.1",
     "phpunit/php-timer" : ">=1.0.6",
-    "nikic/php-parser" : "=1.3.0"
+    "nikic/php-parser" : ">=1.3.0 <1.5"
   },
   "autoload": {
     "classmap": [


### PR DESCRIPTION
Phpdox's composer.json requires nikic/php-parser in version =1.3.0 at the
moment. This can easily conflict with other package's requirements:
e.g. https://github.com/sstalle/php7cc which requires version ~1.4.

After relaxing this requirement with this commit all unit tests still pass.

Resolves: #256