### PR TITLE
Fix phpcs not actually enriching

### DIFF
--- a/src/generator/enricher/checkstyle/CheckStyle.php
+++ b/src/generator/enricher/checkstyle/CheckStyle.php
@@ -88,9 +88,9 @@ namespace TheSeer\phpDox\Generator\Enricher {
 
         }
 
-        protected function processFinding(fDOMDocument $dom, $ref, \DOMElement $finding) {
-            $enrichment = $this->getEnrichtmentContainer($ref, 'checkstyle');
-            $enrichFinding = $dom->createElementNS(self::XMLNS, $finding->getAttribute('severity', 'error'));
+        protected function processFinding(fDOMDocument $dom, $ref, \DOMElement $finding, $elementName = null) {
+            $enrichment    = $this->getEnrichtmentContainer($ref, 'checkstyle');
+            $enrichFinding = $dom->createElementNS(static::XMLNS, ($elementName ?: $finding->getAttribute('severity', 'error')));
             $enrichment->appendChild($enrichFinding);
             foreach($finding->attributes as $attr) {
                 if ($attr->localName == 'severity') {
@@ -98,6 +98,7 @@ namespace TheSeer\phpDox\Generator\Enricher {
                 }
                 $enrichFinding->setAttributeNode($dom->importNode($attr, true));
             }
+            return $enrichFinding;
         }
     }
 

--- a/src/generator/enricher/checkstyle/CheckStyle.php
+++ b/src/generator/enricher/checkstyle/CheckStyle.php
@@ -12,8 +12,11 @@ namespace TheSeer\phpDox\Generator\Enricher {
 
     class CheckStyle extends AbstractEnricher implements ClassEnricherInterface, TraitEnricherInterface, InterfaceEnricherInterface {
 
-        private $config;
-        private $findings = NULL;
+        protected $config;
+        protected $findings = NULL;
+
+        const FINDINGS_XPATH = '/checkstyle/file';
+        const XML_STYLE = 'checkstyle';
 
         public function __construct(CheckStyleConfig $config) {
             $this->config = $config;
@@ -57,12 +60,12 @@ namespace TheSeer\phpDox\Generator\Enricher {
                 }
                 $dom = new fDOMDocument();
                 $dom->load($xmlFile);
-                foreach($dom->query('/checkstyle/file') as $file) {
+                foreach($dom->query(static::FINDINGS_XPATH) as $file) {
                     $this->findings[$file->getAttribute('name')] = $file->query('*');
                 }
             } catch (fDOMException $e) {
                 throw new EnricherException(
-                    'Parsing checkstyle logfile failed: ' . $e->getMessage(),
+                    sprintf('Parsing %s logfile failed: %s', static::XML_STYLE, $e->getMessage()),
                     EnricherException::LoadError
                 );
             }

--- a/src/generator/enricher/phpcs/PHPCs.php
+++ b/src/generator/enricher/phpcs/PHPCs.php
@@ -3,12 +3,6 @@
 namespace TheSeer\phpDox\Generator\Enricher {
 
     use TheSeer\fDOM\fDOMDocument;
-    use TheSeer\fDOM\fDOMElement;
-    use TheSeer\fDOM\fDOMException;
-    use TheSeer\phpDox\Generator\AbstractUnitObject;
-    use TheSeer\phpDox\Generator\ClassStartEvent;
-    use TheSeer\phpDox\Generator\InterfaceStartEvent;
-    use TheSeer\phpDox\Generator\TraitStartEvent;
 
     class PHPCs extends CheckStyle {
 

--- a/src/generator/enricher/phpcs/PHPCs.php
+++ b/src/generator/enricher/phpcs/PHPCs.php
@@ -12,42 +12,14 @@ namespace TheSeer\phpDox\Generator\Enricher {
 
     class PHPCs extends CheckStyle {
 
-        private $config;
-        private $findings = NULL;
         const XMLNS = 'http://xml.phpdox.net/src';
-
-        public function __construct(PHPCsConfig $config) {
-            $this->config = $config;
-            $this->loadFindings($config->getLogFilePath());
-        }
+        const FINDINGS_XPATH = '/phpcs/file';
 
         /**
          * @return string
          */
         public function getName() {
             return 'PHPCS XML';
-        }
-
-        private function loadFindings($xmlFile) {
-            $this->findings = array();
-            try {
-                if (!file_exists($xmlFile)) {
-                    throw new EnricherException(
-                        sprintf('Logfile "%s" not found.', $xmlFile),
-                        EnricherException::LoadError
-                    );
-                }
-                $dom = new fDOMDocument();
-                $dom->load($xmlFile);
-                foreach($dom->query('/phpcs/file') as $file) {
-                    $this->findings[$file->getAttribute('name')] = $file->query('*');
-                }
-            } catch (fDOMException $e) {
-                throw new EnricherException(
-                    'Parsing phpcs logfile failed: ' . $e->getMessage(),
-                    EnricherException::LoadError
-                );
-            }
         }
 
         protected function processFinding(fDOMDocument $dom, $ref, \DOMElement $finding) {

--- a/src/generator/enricher/phpcs/PHPCs.php
+++ b/src/generator/enricher/phpcs/PHPCs.php
@@ -22,17 +22,10 @@ namespace TheSeer\phpDox\Generator\Enricher {
             return 'PHPCS XML';
         }
 
-        protected function processFinding(fDOMDocument $dom, $ref, \DOMElement $finding) {
-            $enrichment = $this->getEnrichtmentContainer($ref, 'checkstyle');
-            $enrichFinding = $dom->createElementNS(self::XMLNS, $finding->tagName);
-            $enrichment->appendChild($enrichFinding);
-            foreach($finding->attributes as $attr) {
-                if ($attr->localName == 'severity') {
-                    continue;
-                }
-                $enrichFinding->setAttributeNode($dom->importNode($attr, true));
-            }
+        protected function processFinding(fDOMDocument $dom, $ref, \DOMElement $finding, $elementName = null) {
+            $enrichFinding = parent::processFinding($dom, $ref, $finding, $finding->tagName);
             $enrichFinding->setAttribute('message', $finding->nodeValue);
+            return $enrichFinding;
         }
     }
 


### PR DESCRIPTION
As mentioned in #236 and #254, it seemed like the reason why the phpcs enricher wasn't working correctly was due to some `private`/`protected` conflicts between parent and child classes.

`PHPCs::loadFindings` was [writing](https://github.com/theseer/phpdox/blob/de5a06f18a6eaf5209cdabb5333ed9309292bf79/src/generator/enricher/phpcs/PHPCs.php#L43) to the `$findings` private property of its class (`PHPCs`)
`CheckStyle::enrichUnit` was [reading](https://github.com/theseer/phpdox/blob/de5a06f18a6eaf5209cdabb5333ed9309292bf79/src/generator/enricher/checkstyle/CheckStyle.php#L44) from the `$findings` private property of *its* class (`CheckStyle`)

As far as `enrichUnit` was concerned, `$this->findings` was empty.

The quick & dirty fix to this was to just change the visibility of `$findings` on both classes to something more permissive.

But since there is a lot of duplicate code in the child class, I refactored a bunch of it away to help simplify things.