### PR TITLE
Fix #315: Convert null to array for count()

### DIFF
--- a/src/shared/FileInfoCollection.php
+++ b/src/shared/FileInfoCollection.php
@@ -64,7 +64,7 @@ namespace TheSeer\phpDox {
          * @return int
          */
         public function count() {
-            return count($this->data);
+            return count((array) $this->data);
         }
 
     }


### PR DESCRIPTION
count(): Parameter must be an array or an object
         that implements Countable

Signed-off-by: Marcel Saegebarth <marc@mos6581.de>