### PR TITLE
style.css: use protocol-relative google font paths

### DIFF
--- a/templates/html/static/css/style.css
+++ b/templates/html/static/css/style.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro);
 
 html {
     background-color: #888888;

--- a/tests/data/issue150/docs/html/css/style.css
+++ b/tests/data/issue150/docs/html/css/style.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro);
+@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro);
 
 html {
     background-color: #888888;


### PR DESCRIPTION
To avoid mixed content warnings when serving phpdox via HTTPS,
use protocol-relative paths to the google font resources instead
of hardcoding HTTP.