### PR TITLE
Fix bad exit status 255 generated by uncaught TypeError

### DIFF
--- a/src/shared/ErrorHandler.php
+++ b/src/shared/ErrorHandler.php
@@ -140,7 +140,7 @@ class ErrorHandler {
     private function getLastError(): array {
         $error = \error_get_last();
 
-        if ($error && $error['type'] === \E_USER_NOTICE) {
+        if ($error === null || $error['type'] === \E_USER_NOTICE) {
             return [];
         }
 


### PR DESCRIPTION
The [error_get_last](https://secure.php.net/error_get_last) function returns NULL if there hasn't been an error yet, And the [exit](https://secure.php.net/exit) status 255 is reserved by PHP and shall be used when fatal
error occurred.

```
$ php -v
PHP 7.2.15-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: Feb  8 2019 15:37:29) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.2.15-1+ubuntu16.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
    with Xdebug v2.6.1, Copyright (c) 2002-2018, by Derick Rethans
```

    PHP Fatal error:  Uncaught TypeError: Return value of TheSeer\phpDox\ErrorHandler::getLastError() must be of the type array,
    null returned in /net/enterprise-data1/home/ad min/gasolwu/Code/phpdox/src/shared/ErrorHandler.php:147
    Stack trace:
    #0 /net/enterprise-data1/home/admin/gasolwu/Code/phpdox/src/shared/ErrorHandler.php(55): TheSeer\phpDox\ErrorHandler->getLastError()
    #1 [internal function]: TheSeer\phpDox\ErrorHandler->handleShutdown()
    #2 {main}
      thrown in /net/enterprise-data1/home/admin/gasolwu/Code/phpdox/src/shared/ErrorHandler.php on line 147
