### PR TITLE
Added object return type support for PHP 7.2

### DIFF
--- a/src/collector/backend/parser/UnitCollectingVisitor.php
+++ b/src/collector/backend/parser/UnitCollectingVisitor.php
@@ -262,7 +262,7 @@ class UnitCollectingVisitor extends NodeVisitorAbstract {
             return;
         }
 
-        if (\in_array($returnType, ['void', 'float', 'int', 'string', 'bool', 'callable', 'array'])) {
+        if (\in_array($returnType, ['void', 'float', 'int', 'string', 'bool', 'callable', 'array', 'object'])) {
             $returnTypeObject = $method->setReturnType($returnType);
             $returnTypeObject->setNullable(false);
 


### PR DESCRIPTION
If a method has `object` as the return type, [which was introduced in PHP 7.2](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.types), the file will be omitted from the documentation.

This fix simply adds `object` to the array of valid return types.