### PR TITLE
Don't namespaces primitive arrays

### DIFF
--- a/src/docblock/elements/VarElement.php
+++ b/src/docblock/elements/VarElement.php
@@ -16,6 +16,18 @@ class VarElement extends GenericElement {
         $node = parent::asDom($ctx);
         $type = $node->getAttribute('type');
 
+        $types = explode('|', $type);
+
+        if (count($types) > 1) {
+            $node->setAttribute('type', 'mixed');
+
+            foreach ($types as $oneType) {
+                $this->typeResolver($node, $oneType);
+            }
+
+            return $node;
+        }
+
         if (\strpos($type, '[]')) {
             $type = \mb_substr($type, 0, -2);
             $node->setAttribute('type', 'array');
@@ -39,5 +51,29 @@ class VarElement extends GenericElement {
         }
 
         return $node;
+    }
+
+    protected function typeResolver(\TheSeer\fDOM\fDOMElement $node, string $type) {
+        $isArray = false;
+        if (substr($type, -2, 2) === '[]') {
+            $isArray = true;
+            $type = substr($type, 0, -2);
+        }
+        $nodeType = $node->appendElementNS(self::XMLNS, 'type');
+        $nodeType->setAttribute('full', $type);
+        $nodeType->setAttribute('array', $isArray?'true':'false');
+
+        if (\in_array($type, $this->types, true)) {
+            $nodeType->setAttribute('name', $type);
+            $nodeType->setAttribute('namespace', '');
+            return;
+        }
+
+        $parts     = \explode('\\', $type);
+        $local     = \array_pop($parts);
+        $namespace = \implode('\\', $parts);
+
+        $nodeType->setAttribute('namespace', $namespace);
+        $nodeType->setAttribute('name', $local);
     }
 }

--- a/src/docblock/parser/GenericParser.php
+++ b/src/docblock/parser/GenericParser.php
@@ -47,6 +47,26 @@ class GenericParser {
     }
 
     protected function lookupType($type) {
+        $types = explode('|', $type);
+
+        foreach ($types as &$oneType) {
+            $isArray = false;
+            if (substr($oneType, -2, 2) === '[]') {
+                $isArray = true;
+                $oneType = substr($oneType, 0, -2);
+            }
+
+            $oneType = $this->lookupOneType($oneType);
+
+            if ($isArray) {
+                $oneType .= '[]';
+            }
+        }
+
+        return implode('|', $types);
+    }
+
+    protected function lookupOneType($type) {
         if ($type === 'self' || $type === 'static') {
             return $this->aliasMap['::unit'];
         }

--- a/templates/html/components.xsl
+++ b/templates/html/components.xsl
@@ -302,6 +302,20 @@
                         <xsl:variable name="ctx" select="pdx:docblock/pdx:var/pdx:type" />
                         <xsl:copy-of select="pdxf:link($ctx, '', $ctx/@full)" />
                     </xsl:when>
+                    <xsl:when test="pdx:docblock/pdx:var/@type = 'array'">
+                        <xsl:variable name="ctx" select="pdx:docblock/pdx:var/pdx:type" />
+                        <xsl:choose>
+                            <xsl:when test="pdx:docblock/pdx:var/@of = 'object'">
+                                <xsl:copy-of select="pdxf:link($ctx, '', $ctx/@full)" />
+                            </xsl:when>
+                            <xsl:otherwise><xsl:value-of select="pdx:docblock/pdx:var/@of" /></xsl:otherwise>
+                        </xsl:choose>[]
+                    </xsl:when>
+                    <xsl:when test="pdx:docblock/pdx:var/@type = 'mixed' and count(pdx:docblock/pdx:var/pdx:type) > 0">
+                        <xsl:for-each select="pdx:docblock/pdx:var/pdx:type">
+                            <xsl:call-template name="mixedvartype" />
+                        </xsl:for-each>
+                    </xsl:when>
                     <xsl:otherwise><xsl:value-of select="pdx:docblock/pdx:var/@type" /></xsl:otherwise>
                 </xsl:choose>
             </xsl:if>
@@ -312,6 +326,18 @@
                 </span>
             </xsl:if>
         </li>
+    </xsl:template>
+
+    <!-- ######################################################################################################### -->
+
+    <xsl:template name="mixedvartype">
+        <span class="multiple">
+        <xsl:choose>
+            <xsl:when test="@name = @full"><xsl:value-of select="@name" /></xsl:when>
+            <xsl:otherwise><xsl:copy-of select="pdxf:link(., '', @full)" /></xsl:otherwise>
+        </xsl:choose>
+        <xsl:if test="@array = 'true'">[]</xsl:if>
+        </span>
     </xsl:template>
 
     <!-- ######################################################################################################### -->

--- a/templates/html/static/css/style.css
+++ b/templates/html/static/css/style.css
@@ -252,6 +252,12 @@ ul.styled {
 ul.members li {
     margin-bottom: 0.5em;
 }
+ul.members li .multiple:after {
+    content: "|";
+}
+ul.members li .multiple:last-child:after {
+    content: '';
+}
 
 .styled h4 {
     padding:0;

--- a/tests/data/issue234/src/ArrayCases.php
+++ b/tests/data/issue234/src/ArrayCases.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace MyNamespace;
+
+class ArrayCases
+{
+    /**
+     * @var int[]
+     */
+    public $arrayOfInt;
+
+    /**
+     * @var boolean[]
+     */
+    public $arrayOfBoolean;
+
+    /**
+     * @var int
+     */
+    public $int;
+
+    /**
+     * @var boolean
+     */
+    public $boolean;
+
+    /**
+     * @var int[]|string[]|SomeClass[]
+     */
+    public $multipleArray;
+
+    /**
+     * @var int|string|SomeClass
+     */
+    public $multiple;
+
+    /**
+     * @var SomeClass[]
+     */
+    public $arrayOfObject;
+
+    /**
+     * @var SomeClass
+     */
+    public $object;
+}

--- a/tests/data/issue234/test.xml
+++ b/tests/data/issue234/test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpdox xmlns="http://xml.phpdox.net/config">
+    <project name="Example" source="${basedir}/src" workdir="${basedir}/xml">
+        <collector backend="parser" />
+
+        <generator output="${basedir}/xml">
+
+            <build engine="html" enabled="true" output="html">
+                <template dir="${phpDox.home}/templates/html" />
+                <file extension="html" />
+            </build>
+
+        </generator>
+    </project>
+</phpdox>


### PR DESCRIPTION
- Handle correctly array of type
- Add test case (tests/data/issue234)
- Better handling of multiple type (piped '|')
- Update html rendering to display array in members definition

Fix #234