### PR TITLE
Fix display of object type on method page

### DIFF
--- a/templates/html/method.xsl
+++ b/templates/html/method.xsl
@@ -185,7 +185,7 @@
         <h2 id="signature">Signature</h2>
         <div class="styled synopsis">
             <code>
-                <xsl:value-of select="$method/@visibility" /> function <xsl:value-of select="$methodName" />(<xsl:if test="$method/pdx:parameter">
+                <xsl:value-of select="$method/@visibility" /> function <xsl:value-of select="$methodName" />( <xsl:if test="$method/pdx:parameter">
                 <xsl:call-template name="parameter">
                     <xsl:with-param name="param" select="$method/pdx:parameter[1]" />
                 </xsl:call-template>&#160;</xsl:if>)
@@ -206,7 +206,7 @@
                     <xsl:variable name="dparam" select="$method/pdx:docblock//pdx:param[@variable = concat('$', $param/@name)]" />
                     <xsl:choose>
                         <xsl:when test="$dparam/@type = 'object'">
-                            <xsl:copy-of select="pdxf:link($dparam/pdx:type, '', $dparam/pdx:type/@name)" />
+                            <xsl:value-of select="$dparam/@type" />
                         </xsl:when>
                         <xsl:otherwise>
                             <xsl:value-of select="$dparam/@type" />


### PR DESCRIPTION
Hello, I found one bug and hunting down them until I've found this fix.

Using one object type will result on an open HTML link before the element leaking over all the page.
It's fixed now.

One extra space was also been added at the beginning for aesthetics purposes (one space at the end, then one at the beginning too).

Thank you for this great tool!