### PR TITLE
Fix PHP7.2 object typehint (#354)

### DIFF
--- a/templates/html/components.xsl
+++ b/templates/html/components.xsl
@@ -325,7 +325,7 @@
             <xsl:if test="@type">
                 —
                 <xsl:choose>
-                    <xsl:when test="@type = 'object'">
+                    <xsl:when test="@type = 'object' and pdx:type">
                         <xsl:copy-of select="pdxf:link(pdx:type, '', pdx:type/@full)" />
                     </xsl:when>
                     <xsl:otherwise><xsl:value-of select="@type" /></xsl:otherwise>
@@ -504,7 +504,7 @@
     <xsl:template name="type">
         <xsl:param name="ctx" />
         <xsl:choose>
-            <xsl:when test="$ctx/pdx:docblock/pdx:return/@type = 'object'"><xsl:value-of select="$ctx/pdx:docblock/pdx:return/pdx:type/@name" /></xsl:when>
+            <xsl:when test="$ctx/pdx:docblock/pdx:return/@type = 'object' and $ctx/pdx:docblock/pdx:return/pdx:type/@name"><xsl:value-of select="$ctx/pdx:docblock/pdx:return/pdx:type/@name" /></xsl:when>
             <xsl:when test="not($ctx/pdx:docblock/pdx:return)">void</xsl:when>
             <xsl:otherwise><xsl:value-of select="$ctx/pdx:docblock/pdx:return/@type" /></xsl:otherwise>
         </xsl:choose>

--- a/templates/html/functions.xsl
+++ b/templates/html/functions.xsl
@@ -47,15 +47,19 @@
                 <xsl:when test="$copy">
                     <xsl:value-of select="$copy"/>
                 </xsl:when>
-                <xsl:otherwise>
+                <xsl:when test="$ctx/@name">
                     <xsl:value-of select="$ctx/@name"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>object</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
 
         <func:result>
+            <xsl:value-of select="$ctx"/>
             <xsl:choose>
-                <xsl:when test="$ctx/@unresolved = 'true'">
+                <xsl:when test="$ctx/@unresolved = 'true' or not($ctx/@full)">
                     <xsl:value-of select="$text"/>
                 </xsl:when>
                 <xsl:otherwise>

--- a/templates/html/synopsis.xsl
+++ b/templates/html/synopsis.xsl
@@ -77,7 +77,7 @@
                 <xsl:for-each select="$unit/pdx:docblock/*[self::pdx:property or self::pdx:property-read or self::pdx:property-write]">
                     <li>
                         <i>magic<xsl:if test="local-name() = 'property-read'"> (r/o)</xsl:if><xsl:if test="local-name() = 'property-write'"> (w/o)</xsl:if></i>&#160;<xsl:choose>
-                            <xsl:when test="@type = 'object'">
+                            <xsl:when test="@type = 'object' and pdx:type/@name">
                                 <xsl:value-of select="pdx:type/@name" />
                             </xsl:when>
                             <xsl:when test="@type = '{unknown}'">
@@ -144,10 +144,11 @@
 
     <xsl:template name="vartype">
         <xsl:choose>
-            <xsl:when test="pdx:docblock/pdx:var/@type = 'object'">&#160;<span title="{pdx:docblock/pdx:var/pdx:type/@full}"><xsl:value-of select="pdx:docblock/pdx:var/pdx:type/@name" /></span></xsl:when>
+            <xsl:when test="pdx:docblock/pdx:var/@type = 'object' and pdx:docblock/pdx:var/pdx:type">&#160;<span title="{pdx:docblock/pdx:var/pdx:type/@full}"><xsl:value-of select="pdx:docblock/pdx:var/pdx:type/@name" /></span></xsl:when>
             <xsl:when test="@type = '{unknown}'">
                 <xsl:if test="pdx:docblock/pdx:var/@type">&#160;<xsl:value-of select="pdx:docblock/pdx:var/@type" /></xsl:if>
             </xsl:when>
+            <xsl:when test="pdx:docblock/pdx:var/@type and not(@type)">&#160;<xsl:value-of select="pdx:docblock/pdx:var/@type" /></xsl:when>
             <xsl:otherwise>&#160;<xsl:value-of select="@type" /></xsl:otherwise>
         </xsl:choose>
     </xsl:template>
@@ -159,11 +160,11 @@
         <xsl:choose>
             <xsl:when test="pdx:return"><xsl:if test="pdx:return/@nullable = 'true'">?</xsl:if>
                 <xsl:choose>
-                    <xsl:when test="pdx:return/@type = 'object'"><span title="{pdx:return/pdx:type/@name}"><xsl:value-of select="pdx:return/pdx:type/@name" /></span></xsl:when>
+                    <xsl:when test="pdx:return/@type = 'object' and pdx:return/pdx:type"><span title="{pdx:return/pdx:type/@name}"><xsl:value-of select="pdx:return/pdx:type/@name" /></span></xsl:when>
                     <xsl:otherwise><xsl:value-of select="pdx:return/@type" /></xsl:otherwise>
                 </xsl:choose>
             </xsl:when>
-            <xsl:when test="pdx:docblock/pdx:return/@type = 'object'"><xsl:value-of select="pdx:docblock/pdx:return/pdx:type/@name" /></xsl:when>
+            <xsl:when test="pdx:docblock/pdx:return/@type = 'object' and pdx:docblock/pdx:return/pdx:type"><xsl:value-of select="pdx:docblock/pdx:return/pdx:type/@name" /></xsl:when>
             <xsl:when test="not(pdx:docblock/pdx:return)">void</xsl:when>
             <xsl:otherwise><xsl:value-of select="pdx:docblock/pdx:return/@type" /></xsl:otherwise>
         </xsl:choose>

--- a/tests/data/issue354/src/test.php
+++ b/tests/data/issue354/src/test.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Class Php72ObjectTypeClass
+ *
+ * @method object getObject()
+ * @method \IteratorIterator getClassObject()
+ *
+ * @property object $magicObject
+ * @property \SplStack $magicClassObject
+ */
+class Php72ObjectTypeClass {
+
+    /**
+     * @var object
+     */
+    public $object;
+
+    /**
+     * @var \ArrayObject
+     */
+    public $class;
+
+    function objectReturn(): object {
+        return new stdClass();
+    }
+
+    function objectParam(object $param) {}
+
+    /**
+     * @param object $param
+     */
+    function objectParamPhpDoc($param) {}
+
+    public function classParam(SplFileInfo $file) {}
+
+    /**
+     * @param \SplFileInfo $file
+     */
+    public function classParamPhpDoc($file) {}
+
+    /**
+     * @return object
+     */
+    public function objectReturnPhpDoc() {
+        return new stdClass();
+    }
+
+    function stringReturn(): string {
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    function stringReturnPhpDoc() {
+        return '';
+    }
+
+    function classReturn(): DateTime {
+        return new DateTime();
+    }
+
+    /**
+     * @return \DateTime
+     */
+    function classReturnPhpDoc() {
+        return new DateTime();
+    }
+}

--- a/tests/data/issue354/test.xml
+++ b/tests/data/issue354/test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpdox xmlns="http://xml.phpdox.net/config" silent="false">
+
+    <project name="phpDox-issue" source="${basedir}/src" workdir="${basedir}/xml">
+
+        <collector publiconly="false" backend="parser" />
+
+        <generator output="${basedir}/docs">
+            <build engine="html" enabled="true" output="html" />
+            <build engine="xml" enabled="true" output="xml" />
+        </generator>
+
+    </project>
+
+</phpdox>


### PR DESCRIPTION
I should have covered all cases.

How I handle it: when the type `object` is tested, I also check if the type have been resolved (<=> a full class path exist)

----

But I think the type transformation should be reworked, lots of similar XSL instruction exists. They look alike but are slightly different, which cause the _maintainability cost_ to be quite high.

All those cases should be refactored into one XSLT function (or at least be in the same file, to avoid searching in multiple places). 