### PR TITLE
Use SHA1 to generate filename.

### DIFF
--- a/src/collector/project/Project.php
+++ b/src/collector/project/Project.php
@@ -238,7 +238,7 @@ class Project {
                 ProjectException::UnitNotFoundInIndex
             );
         }
-        $name                    = \str_replace('\\', '_', $unit->getName());
+        $name                    = sha1($unit->getName());
         $dom                     = $unit->export();
         $dom->formatOutput       = true;
         $dom->preserveWhiteSpace = false;

--- a/src/generator/engine/html/Html.php
+++ b/src/generator/engine/html/Html.php
@@ -194,6 +194,8 @@ class Html extends AbstractEngine {
             $xsl->setParameter('', 'project', $this->projectNode->getAttribute('name'));
         }
 
+        $xsl->registerPHPFunctions('sha1');
+
         return $xsl;
     }
 
@@ -256,7 +258,7 @@ class Html extends AbstractEngine {
     }
 
     private function classNameToFileName($class, $method = null) {
-        $name = \str_replace('\\', '_', $class);
+        $name = sha1($class);
 
         if ($method !== null) {
             $name .= '/' . $method;

--- a/src/generator/engine/xml/Xml.php
+++ b/src/generator/engine/xml/Xml.php
@@ -45,9 +45,10 @@ class Xml extends AbstractEngine {
             }
         }
         $dom = $ctx->asDom();
+        $fname = sha1($dom->documentElement->getAttribute('full'));
         $this->saveDomDocument(
             $dom,
-            $this->outputDir . '/' . $path . '/' . \str_replace('\\', '_', $dom->documentElement->getAttribute('full')) . '.xml'
+            $this->outputDir . '/' . $path . '/' . $fname . '.xml'
         );
     }
 

--- a/templates/html/functions.xsl
+++ b/templates/html/functions.xsl
@@ -7,8 +7,9 @@
                 xmlns:idx="http://xml.phpdox.net/src"
                 xmlns:git="http://xml.phpdox.net/gitlog"
                 xmlns:ctx="ctx://engine/html"
+                xmlns:php="http://php.net/xsl"
                 extension-element-prefixes="func"
-                exclude-result-prefixes="idx pdx pdxf pu git ctx">
+                exclude-result-prefixes="idx pdx pdxf pu git ctx php">
 
     <func:function name="pdxf:link">
         <xsl:param name="ctx"/>
@@ -39,7 +40,7 @@
 
         <xsl:variable name="link">
             <xsl:value-of
-                    select="concat($base, $dir, '/', translate($ctx/@full, '\', '_'), $withMethod, '.', $extension)"/>
+                    select="concat($base, $dir, '/', php:function('sha1', concat('', $ctx/@full)), $withMethod, '.', $extension)"/>
         </xsl:variable>
 
         <xsl:variable name="text">

--- a/templates/html/units.xsl
+++ b/templates/html/units.xsl
@@ -7,8 +7,9 @@
                 xmlns:idx="http://xml.phpdox.net/src"
                 xmlns:git="http://xml.phpdox.net/gitlog"
                 xmlns:ctx="ctx://engine/html"
+                xmlns:php="http://php.net/xsl"
                 extension-element-prefixes="func"
-                exclude-result-prefixes="idx pdx pdxf pu git ctx">
+                exclude-result-prefixes="idx pdx pdxf pu git ctx php">
 
     <xsl:import href="components.xsl" />
 
@@ -49,11 +50,15 @@
                     <xsl:for-each select="*[local-name() = $mode]">
                         <xsl:sort select="@name" order="ascending" />
 
+                        <xsl:variable name="fullclass"><xsl:choose>
+                            <xsl:when test="../@name != ''"><xsl:value-of select="concat(../@name, '\')" /></xsl:when>
+                            <xsl:otherwise/>
+                        </xsl:choose><xsl:value-of select="@name" /></xsl:variable>
                         <xsl:variable name="link"><xsl:choose>
                             <xsl:when test="local-name(.) = 'class'">classes</xsl:when>
                             <xsl:when test="local-name(.) = 'interface'">interfaces</xsl:when>
                             <xsl:otherwise>traits</xsl:otherwise>
-                        </xsl:choose>/<xsl:value-of select="translate(../@name, '\', '_')" /><xsl:if test="not(../@name = '')">_</xsl:if><xsl:value-of select="@name" />.<xsl:value-of select="$extension" /></xsl:variable>
+                        </xsl:choose>/<xsl:value-of select="php:function('sha1', $fullclass)" />.<xsl:value-of select="$extension" /></xsl:variable>
                         <tr>
                             <td><a href="{$link}"><xsl:value-of select="@name" /></a></td>
                             <td>

--- a/tests/data/issue351/src/Lorem/ipsum/dolor/sit/amet/consectetur/adipiscing/elit/Phasellus/aliquet/lacus/vel/lectus/vehicula/facilisis/quis/eu/ex/Duis/dignissim/test.php
+++ b/tests/data/issue351/src/Lorem/ipsum/dolor/sit/amet/consectetur/adipiscing/elit/Phasellus/aliquet/lacus/vel/lectus/vehicula/facilisis/quis/eu/ex/Duis/dignissim/test.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lorem\ipsum\dolor\sit\amet\consectetur\adipiscing\elit\Phasellus\aliquet\lacus\vel\lectus\vehicula\facilisis\quis\eu\ex\Duis\dignissim;
+
+class NequePorroQuisquamEstQuiDoloremIpsumQuiaDolorSitAmetConsecteturAdipisciVelit
+{
+    public $var = 'hello';
+    const A_PLACE = 'world';
+
+    function f() {
+        // ...
+    }
+}

--- a/tests/data/issue351/src/test.php
+++ b/tests/data/issue351/src/test.php
@@ -1,0 +1,8 @@
+<?php
+
+class NoNamespace {
+    function foo()
+    {
+        // ...
+    }
+}

--- a/tests/data/issue351/test.xml
+++ b/tests/data/issue351/test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpdox xmlns="http://xml.phpdox.net/config" silent="false">
+
+    <project name="phpDox-issue" source="${basedir}/src" workdir="${basedir}/xml">
+
+        <collector publiconly="false" backend="parser" />
+
+        <generator output="${basedir}/docs">
+            <build engine="html" enabled="true" output="html" />
+            <build engine="xml" enabled="true" output="xml" />
+        </generator>
+
+    </project>
+
+</phpdox>


### PR DESCRIPTION
Replace the '\' to '_' class FQN transformation by SHA1 to prevent issue with filename being too long.

Close #351