### PR TITLE
Fix PHPUnit 9 compatibility for expectedException.

### DIFF
--- a/tests/Unit/DirectoryCleanerTest.php
+++ b/tests/Unit/DirectoryCleanerTest.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types = 1);
 namespace TheSeer\phpDox;
 
+use TheSeer\phpDox\DirectoryCleanerException;
+
 class DirectoryCleanerTest extends \PHPUnit\Framework\TestCase {
     /**
      * @var DirectoryCleaner
@@ -11,11 +13,10 @@ class DirectoryCleanerTest extends \PHPUnit\Framework\TestCase {
         $this->cleaner = new DirectoryCleaner();
     }
 
-    /**
-     * @expectedException \TheSeer\phpDox\DirectoryCleanerException
-     * @expectedExceptionCode \TheSeer\phpDox\DirectoryCleanerException::SecurityLimitation
-     */
     public function testTryingToDeleteAShortPathThrowsException(): void {
+        self::expectException(DirectoryCleanerException::class);
+        self::expectExceptionCode(DirectoryCleanerException::SecurityLimitation);
+
         $this->cleaner->process(new FileInfo('/tmp'));
     }
 

--- a/tests/Unit/config/GlobalConfigTest.php
+++ b/tests/Unit/config/GlobalConfigTest.php
@@ -2,6 +2,7 @@
 namespace TheSeer\phpDox;
 
 use TheSeer\fDOM\fDOMDocument;
+use TheSeer\phpDox\ConfigException;
 
 /**
  * Class GlobalConfigTest
@@ -40,11 +41,10 @@ class GlobalConfigTest extends \PHPUnit\Framework\TestCase {
         $this->baseDir = \realpath(__DIR__ . '/../../data/config') . '/';
     }
 
-    /**
-     * @expectedException \TheSeer\phpDox\ConfigException
-     * @expectedExceptionCode \TheSeer\phpDox\ConfigException::InvalidDataStructure
-     */
     public function testTryingToLoadInvalidConfigThrowsException(): void {
+        self::expectException(ConfigException::class);
+        self::expectExceptionCode(ConfigException::InvalidDataStructure);
+
         $this->init('broken');
     }
 

--- a/tests/Unit/docblock/DocBlockTest.php
+++ b/tests/Unit/docblock/DocBlockTest.php
@@ -3,6 +3,7 @@ namespace TheSeer\phpDox\DocBlock;
 
 use PHPUnit\Framework\TestCase;
 use TheSeer\fDOM\fDOMDocument;
+use TheSeer\phpDox\DocBlock\DocBlockException;
 
 /**
  * Class DocBlockTest
@@ -58,10 +59,11 @@ class DocBlockTest extends TestCase {
     }
 
     /**
-     * @expectedException \TheSeer\phpDox\DocBlock\DocBlockException
      * @covers \TheSeer\phpDox\DocBlock\DocBlock::getElementByName
      */
     public function testTryingToGetANonExistingElementThrowsException(): void {
+        self::expectException(DocBlockException::class);
+
         $this->docBlock->getElementByName('non-set');
     }
 

--- a/tests/Unit/docblock/FactoryTest.php
+++ b/tests/Unit/docblock/FactoryTest.php
@@ -3,6 +3,7 @@ namespace TheSeer\phpDox\Tests\Unit\DocBlock;
 
 use TheSeer\fDOM\fDOMDocument;
 use TheSeer\phpDox\DocBlock\Factory;
+use TheSeer\phpDox\DocBlock\FactoryException;
 use TheSeer\phpDox\DocBlock\GenericParser;
 use TheSeer\phpDox\DocBlock\InlineProcessor;
 use TheSeer\phpDox\FactoryInterface;
@@ -38,10 +39,11 @@ class FactoryTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @expectedException \TheSeer\phpDox\DocBlock\FactoryException
      * @covers \TheSeer\phpDox\DocBlock\Factory::addParserFactory
      */
     public function testAddParserFactoryExpectingFactoryException(): void {
+        self::expectException(FactoryException::class);
+
         $mock = $this->createMock(FactoryInterface::class);
         $this->factory->addParserFactory([], $mock);
     }
@@ -56,10 +58,11 @@ class FactoryTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @dataProvider addParserClassDataprovider
-     * @expectedException \TheSeer\phpDox\DocBlock\FactoryException
      * @covers       \TheSeer\phpDox\DocBlock\Factory::addParserClass
      */
     public function testAddParserClassExpectingFactoryException($annotation, $classname): void {
+        self::expectException(FactoryException::class);
+
         $this->factory->addParserClass($annotation, $classname);
     }
 


### PR DESCRIPTION
Hi,
I removed the deprecated "@expectedException" annotations and used the "expectException()" methods instead.