### PR TITLE
Fix doc bootstrap

### DIFF
--- a/src/collector/backend/parser/UnitCollectingVisitor.php
+++ b/src/collector/backend/parser/UnitCollectingVisitor.php
@@ -266,7 +266,10 @@ class UnitCollectingVisitor extends NodeVisitorAbstract implements TypeAwareInte
             return;
         }
 
-        if ($this->isBuiltInType((string)$returnType, self::TYPE_RETURN)) {
+        $typeStr = $returnType instanceof NullableType
+            ? ((string)$returnType->type)
+            : ((string)$returnType);
+        if ($this->isBuiltInType($typeStr, self::TYPE_RETURN)) {
             $returnTypeObject = $method->setReturnType($returnType);
             $returnTypeObject->setNullable(false);
 


### PR DESCRIPTION
I tried running `./phpdox` for phpdox repo itself, got:
```
PHP Version: 7.4.0 (Darwin)
PHPDox Version: 0.12.0-17-g4c380a2-dirty
Exception: Error (Code: 0)
Location: /Users/me/misc/phpdox/src/collector/backend/parser/UnitCollectingVisitor.php (Line 269)

Object of class PhpParser\Node\NullableType could not be converted to string
```
I believe it's incorrect behavior, so I fixed this.