### PR TITLE
Fix git version check

### DIFF
--- a/src/generator/enricher/git/Git.php
+++ b/src/generator/enricher/git/Git.php
@@ -345,6 +345,9 @@ class Git extends AbstractEnricher implements FullEnricherInterface {
 
     private function ensureGitVersionSupported($binary): void {
         $output  = \exec(\sprintf('%s --version', $binary));
+        if (\preg_match('/Apple Git/', $output)) {
+            $output = \preg_replace('/\s+\(Apple Git-\d+(\.\d+)?\)/', '', $output);
+        }
         $parts   = \explode(' ', $output);
         $version = \array_pop($parts);
 


### PR DESCRIPTION
Git version check run incorrectly on my device. I use mac os, `git --version` returns:
```
git version 2.21.0 (Apple Git-122.2)
```
When running phpdox, I got incorrect warning:
```
    Your version of GIT is too old. Please upgrade to at least version 1.7.2 (Found: Git-122.2))
```
This output format was not supported, now it is fixed.