### PR TITLE
Updating PHPUnit to make tests compatible with PHP 7.4

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="phploc" version="^3.0.1" installed="3.0.1" location="./tools/phploc" copy="false"/>
-  <phar name="phpunit" version="^7.0" installed="7.5.3" location="./tools/phpunit" copy="false"/>
+  <phar name="phpunit" version="^7.0" installed="7.5.19" location="./tools/phpunit" copy="false"/>
   <phar name="phpab" version="^1.25.2" installed="1.25.2" location="./tools/phpab" copy="false"/>
 </phive>


### PR DESCRIPTION
Hi,

Since PHP 7.4, some tests are failing due to PHPUnit's use of `ReflectionType::__toString()`.
This behavior has been changed in [PHPUnit 7.5.15](https://github.com/sebastianbergmann/phpunit/blob/7.5/ChangeLog-7.5.md).
I updated the dependency to 7.5.19 and the tests are OK.