### PR TITLE
Update Environment.php

### DIFF
--- a/src/shared/Environment.php
+++ b/src/shared/Environment.php
@@ -43,7 +43,11 @@ class Environment {
         \ini_set('xdebug.scream', 'off');
         \ini_set('xdebug.max_nesting_level', '8192');
         \ini_set('xdebug.show_exception_trace', 'off');
-        xdebug_disable();
+        \ini_set('xdebug.mode', 'off');
+
+        if (function_exists('xdebug_disable')) {
+            xdebug_disable();
+        }
     }
 
     private function ensureTimezoneSet(): void {


### PR DESCRIPTION
Since xdebug version 3.0.0 removed function xdebug_disable(), this raise exception 
`Call to undefined function TheSeer\phpDox\xdebug_disable()`.