### PR TITLE
Avoid dynamic properties creation

### DIFF
--- a/src/bootstrap/Bootstrap.php
+++ b/src/bootstrap/Bootstrap.php
@@ -2,6 +2,17 @@
 namespace TheSeer\phpDox;
 
 class Bootstrap {
+
+    /**
+     * @var ProgressLogger
+     */
+    private $logger;
+
+    /**
+     * @var BootstrapApi
+     */
+    private $api;
+
     public function __construct(ProgressLogger $logger, BootstrapApi $api) {
         $this->logger = $logger;
         $this->api    = $api;

--- a/src/bootstrap/BootstrapApi.php
+++ b/src/bootstrap/BootstrapApi.php
@@ -66,6 +66,11 @@ class BootstrapApi {
     private $backends = [];
 
     /**
+     * @var ProgressLogger
+     */
+    private $logger;
+
+    /**
      * Constructor
      */
     public function __construct(BackendFactory $bf, DocBlockFactory $df, EnricherFactory $erf, EngineFactory $enf, ProgressLogger $logger) {


### PR DESCRIPTION
PHP 8.2 deprecated the dynamic object creation, by setting unknown properties.

This fixes the following issue:
Creation of dynamic property TheSeer\phpDox\Bootstrap::$api is deprecated

Fixes #425