### PR TITLE
Php8.1 compatibility

### DIFF
--- a/src/collector/SourceFileIterator.php
+++ b/src/collector/SourceFileIterator.php
@@ -41,6 +41,7 @@ class SourceFileIterator implements \Iterator {
      *
      * @return mixed scalar on success, or null on failure
      */
+    #[\ReturnTypeWillChange]
     public function key() {
         return $this->iterator->key();
     }

--- a/src/generator/project/TokenFileIterator.php
+++ b/src/generator/project/TokenFileIterator.php
@@ -29,10 +29,12 @@ class TokenFileIterator implements \Iterator {
         $this->pos++;
     }
 
+    #[\ReturnTypeWillChange]
     public function key() {
         return $this->pos;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid() {
         return $this->nodeList->length > $this->pos;
     }

--- a/src/generator/project/collections/AbstractCollection.php
+++ b/src/generator/project/collections/AbstractCollection.php
@@ -36,6 +36,7 @@ abstract class AbstractCollection implements \Iterator {
      *
      * @return mixed scalar on success, or null on failure
      */
+    #[\ReturnTypeWillChange]
     public function key() {
         return $this->position;
     }

--- a/src/shared/FileInfo.php
+++ b/src/shared/FileInfo.php
@@ -9,6 +9,7 @@ class FileInfo extends \SplFileInfo {
     /**
      * @throws FileInfoException
      */
+    #[\ReturnTypeWillChange]
     public function getRealPath() {
         $path = parent::getRealPath();
 
@@ -38,6 +39,7 @@ class FileInfo extends \SplFileInfo {
         return 'file://' . urlencode($result);
     }
 
+    #[\ReturnTypeWillChange]
     public function getPath() {
         return $this->toUnix(parent::getPath());
     }
@@ -70,6 +72,7 @@ class FileInfo extends \SplFileInfo {
      *
      * @throws FileInfoException
      */
+    #[\ReturnTypeWillChange]
     public function getFileInfo($class_name = null): void {
         throw new FileInfoException('getFileInfo not implemented', FileInfoException::NotImplemented);
     }
@@ -79,6 +82,7 @@ class FileInfo extends \SplFileInfo {
      *
      * @throws FileInfoException
      */
+    #[\ReturnTypeWillChange]
     public function getPathInfo($class_name = null): void {
         throw new FileInfoException('getPathInfo not implemented', FileInfoException::NotImplemented);
     }

--- a/src/xsl/fxsltprocessorbase.php
+++ b/src/xsl/fxsltprocessorbase.php
@@ -149,6 +149,7 @@ namespace TheSeer\fXSL {
          *
          * Extended version to throw exception on error
          */
+        #[\ReturnTypeWillChange]
         public function importStylesheet($stylesheet) {
             if ($stylesheet->documentElement->namespaceURI != 'http://www.w3.org/1999/XSL/Transform') {
                 throw new fXSLTProcessorException(
@@ -164,6 +165,7 @@ namespace TheSeer\fXSL {
          *
          * Extended version to enforce callability of fXSLProcessor::callbackHook and generally callable methods
          */
+        #[\ReturnTypeWillChange]
         public function registerPHPFunctions($restrict = NULL) {
             if (is_string($restrict)) {
                 $restrict = array($restrict);


### PR DESCRIPTION
A few more PHP8.1 compatibility changes, additions of #[\ReturnTypeWillChange]


please also consider the following change in fDOMDocument ( I know it is archived )

https://github.com/theseer/fDOMDocument/compare/master...pugelarouge:fDOMDocument:PHP8.1
( src/fDOMDocument.php :: 250 - save() $option default value to 0 form NULL )